### PR TITLE
Replace "begs" with "raises"

### DIFF
--- a/docs/papers/git-horror-story.txt
+++ b/docs/papers/git-horror-story.txt
@@ -342,7 +342,7 @@ Date:   Sat Apr 21 00:14:38 2012 -0400
 # [...]
 ----
 
-This then begs the questions---what is to be done about those who decide to
+This then raises the question---what is to be done about those who decide to
 sign their commit with their own GPG key? There are a couple options here.
 First, consider the issue from a maintainer's perspective---do we necessary
 care about the identity of a 3rd party contributor, so long as the provided code


### PR DESCRIPTION
"Begging the question" and "raising the question" mean different things. This patch fixes an instance where it is misused.

See: http://begthequestion.info/